### PR TITLE
Refactor App to be a function component

### DIFF
--- a/christmas_2021/src/lib.rs
+++ b/christmas_2021/src/lib.rs
@@ -5,26 +5,13 @@ use routes::{switch, Route};
 use yew::prelude::*;
 use yew_router::prelude::*;
 
-pub struct App;
-
-impl Component for App {
-    type Message = ();
-
-    type Properties = ();
-
-    fn create(_ctx: &Context<Self>) -> Self {
-        // get the link information here and store it
-        Self
-    }
-
-    fn view(&self, _ctx: &Context<Self>) -> Html {
-        // pass in the router information via a property
-        html! {
-            <BrowserRouter>
-                <main>
-                    <Switch<Route> render={Switch::render(switch)} />
-                </main>
-            </BrowserRouter>
-        }
+#[function_component(App)]
+pub fn app() -> Html {
+    html! {
+        <BrowserRouter>
+            <main>
+                <Switch<Route> render={Switch::render(switch)} />
+            </main>
+        </BrowserRouter>
     }
 }


### PR DESCRIPTION
hi @BrooksPatton ,

I have been enjoying your presentation of the Yew framework. 

This PR is regarding your discussion here: [https://youtu.be/2-NfdkAPeGE?t=9229](https://youtu.be/2-NfdkAPeGE?t=9229) According to the documentation, `start_app` requires the type `Component`. A function component works just fine.